### PR TITLE
fix: update lrelease executable search paths for Qt5/Qt6 (#27)

### DIFF
--- a/src/translate_generation.sh
+++ b/src/translate_generation.sh
@@ -4,6 +4,15 @@
 
 ts_list=(`ls ../translations/*.ts`)
 
+# 优先使用Qt6 lrelease工具
+if [ -f "/usr/lib/qt6/bin/lrelease" ]; then
+    lrelease="/usr/lib/qt6/bin/lrelease" 
+elif [ -f "/usr/lib/qt5/bin/lrelease" ]; then
+    lrelease="/usr/lib/qt5/bin/lrelease"
+else
+    lrelease="lrelease"
+fi
+
 for ts in "${ts_list[@]}"
 do
     printf "\nprocess ${ts}\n"


### PR DESCRIPTION
Add specific search paths for lrelease in Qt5 and Qt6 directories before falling back to default system path.

Log: update lrelease executable search paths for Qt5/Qt6