### PR TITLE
fix: use lrelease variable reference in translation script

### DIFF
--- a/src/translate_generation.sh
+++ b/src/translate_generation.sh
@@ -16,5 +16,5 @@ fi
 for ts in "${ts_list[@]}"
 do
     printf "\nprocess ${ts}\n"
-    lrelease "${ts}"
+    ${lrelease} "${ts}"
 done


### PR DESCRIPTION
- Update the lrelease command execution to use proper variable reference
- Ensure correct Qt lrelease binary is used based on previous path detection

Log: use lrelease variable reference in translation script